### PR TITLE
Fixed testSendReceive() unit test assertion

### DIFF
--- a/testing-samples/test-embedded-kafka/src/test/java/demo/EmbeddedKafkaApplicationTests.java
+++ b/testing-samples/test-embedded-kafka/src/test/java/demo/EmbeddedKafkaApplicationTests.java
@@ -100,7 +100,7 @@ public class EmbeddedKafkaApplicationTests {
 		consumer.commitSync();
 
 		assertThat(records.count()).isEqualTo(1);
-		assertThat(new String(records.iterator().next().value())).isEqualTo("FOO");
+		assertThat(new String(records.iterator().next().value())).isEqualTo("foo");
 	}
 
 }


### PR DESCRIPTION
Changed from FOO to foo.
The test uses template.sendDefault("foo".getBytes());  but it checks for  "FOO:.
So :
`assertThat(new String(records.iterator().next().value())).isEqualTo("FOO");` 
should be 
`assertThat(new String(records.iterator().next().value())).isEqualTo("foo");`